### PR TITLE
Phone_mask_transformation

### DIFF
--- a/force-app/main/default/classes/Constants.cls
+++ b/force-app/main/default/classes/Constants.cls
@@ -1,3 +1,10 @@
+/**
+ * @description       : 
+ * @author            : ChangeMeIn@UserSettingsUnder.SFDoc
+ * @group             : 
+ * @last modified on  : 10-24-2025
+ * @last modified by  : ChangeMeIn@UserSettingsUnder.SFDoc
+**/
 public with sharing class Constants {
     public static final String BOOLEAN_TYPE = 'Boolean';
     public static final String DATE_TYPE = 'Date';
@@ -86,7 +93,38 @@ public with sharing class Constants {
 
 
 
-
+    /**
+     * Liste d’indicatifs connus avec la longueur du numéro local.
+     * Permet de conserver une structure réaliste pour le numéro généré.
+    */
+    public static final Map<String, Integer> COUNTRY_CODE_DIGITS = new Map<String, Integer>{
+        '+1' => 10,     // USA, Canada
+        '+33' => 9,     // France
+        '+221' => 9,    // Sénégal
+        '+32' => 9,     // Belgique
+        '+41' => 9,     // Suisse
+        '+212' => 9,    // Maroc
+        '+225' => 10,   // Côte d’Ivoire
+        '+237' => 9,    // Cameroun
+        '+44' => 10,    // Royaume-Uni
+        '+49' => 10,    // Allemagne
+        '+34' => 9,     // Espagne
+        '+39' => 10,    // Italie
+        '+351' => 9,    // Portugal
+        '+216' => 8,    // Tunisie
+        '+91' => 10,    // Inde
+        '+86' => 11,    // Chine
+        '+81' => 10,    // Japon
+        '+61' => 9,     // Australie
+        '+7' => 10,     // Russie
+        '+254' => 9,    // Kenya
+        '+233' => 9,    // Ghana
+        '+234' => 10,   // Nigeria
+        '+971' => 9,    // Émirats Arabes Unis
+        '+90' => 10,    // Turquie
+        '+48' => 9,     // Pologne
+        '+30' => 10     // Grèce
+    };
 
 
 }

--- a/force-app/main/default/classes/test/PhoneMaskTransformationTest.cls
+++ b/force-app/main/default/classes/test/PhoneMaskTransformationTest.cls
@@ -1,0 +1,127 @@
+/**
+ * @description Tests unitaires pour la classe PhoneMaskTransformation
+ * @group TransformationRules
+ * @date 2025-10-24
+ */
+@IsTest
+public class PhoneMaskTransformationTest {
+
+    @testSetup
+    static void setup() {
+        // Préparation d’un projet et d’un mapping
+        TestDataFactory.createAdminUser();
+        ImportProject__c project = TestDataFactory.createImportProject('Lead');
+
+        insert new FieldMapping__c(
+            Project__c = project.Id,
+            SourceColumn__c = 'IsActive',
+            TargetField__c = 'DoNotCall',
+            IsLookup__c = false
+        );
+    }
+
+    /** 
+     * Méthode utilitaire de création de règle de transformation 
+     */
+    static TransformationRule__c createRule(String params, String targetValue) { 
+
+        ImportProject__c project = [SELECT Id FROM ImportProject__c LIMIT 1];
+        FieldMapping__c mapping = [
+            SELECT Id, TargetField__c 
+            FROM FieldMapping__c 
+            WHERE SourceColumn__c = 'IsActive' 
+            LIMIT 1
+        ];
+
+        TransformationRule__c rule = new TransformationRule__c(
+            Project__c = project.Id,
+            FieldMapping__c = mapping.Id,
+            RuleType__c = 'PhoneMask',
+            Parameters__c = params,
+            TargetValue__c = targetValue,
+            Order__c = 1
+        );
+        insert rule;
+
+        return [
+            SELECT Id, Parameters__c, TargetValue__c, FieldMapping__r.TargetField__c 
+            FROM TransformationRule__c 
+            WHERE Id = :rule.Id
+        ]; 
+
+    }
+
+    /**
+     * Test principal : Vérifie qu’un numéro est transformé correctement.
+     */
+    @IsTest
+    static void testApplyTransformation_Success() {
+        Test.startTest();
+        // GIVEN
+        String params = '{"phone":"+221 77 888 88 88","targetType":"phone"}';
+        TransformationRule__c rule = createRule(params, 'default');
+
+        FieldMapping__c mapping = [
+            SELECT TargetField__c
+            FROM FieldMapping__c
+            WHERE SourceColumn__c = 'IsActive'
+            LIMIT 1
+        ];
+        PhoneMaskTransformation transformer = new PhoneMaskTransformation();
+
+        // WHEN
+        String result = transformer.apply(
+            new Map<String, String>{mapping.TargetField__c => '+221 78 888 88 88'},
+            rule
+        );
+
+        // THEN
+        Assert.areNotEqual(null, result, 'Le résultat ne doit pas être null.'); 
+        Assert.isTrue(result.length() >= 8, 'Le numéro généré doit contenir plusieurs chiffres.');
+        Test.stopTest();
+    }
+
+    /**
+     * Test : Validation d’un numéro invalide.
+     */
+    @IsTest
+    static void testValidate_InvalidNumber() {
+        Test.startTest();
+
+        TransformationRule__c rule = createRule('{"phone":"blabla",targetType:"phone"}', null);
+                FieldMapping__c mapping = [SELECT TargetField__c FROM FieldMapping__c WHERE SourceColumn__c = 'IsActive' LIMIT 1];
+
+        PhoneMaskTransformation transformer = new PhoneMaskTransformation();
+
+        Boolean isValid = transformer.validate(
+            new Map<String, String>{mapping.Id => 'not_a_phone'},
+            rule
+        );
+
+        Assert.isFalse(isValid, 'Le numéro ne devrait pas être valide.');
+        Test.stopTest();
+
+    }
+
+    /**
+     * Test : Gestion d’une erreur inattendue.
+     */
+    @IsTest
+    static void testApplyTransformation_Exception() {
+        Test.startTest();
+        // GIVEN - envoi d’un JSON corrompu
+        String params = '{"phone":}';
+        TransformationRule__c rule = createRule(params, 'default');
+        PhoneMaskTransformation transformer = new PhoneMaskTransformation();
+
+        // WHEN / THEN
+        try {
+            transformer.apply(new Map<String, String>(), rule);
+            Assert.isNotNull(false, 'Une exception aurait dû être levée.');
+        } catch (Exception e) {
+            Assert.isNotNull(e.getMessage().contains('Erreur de génération'), 'Le message d’erreur doit être explicite.');
+        }
+        Test.stopTest();
+
+    }
+}

--- a/force-app/main/default/classes/test/PhoneMaskTransformationTest.cls-meta.xml
+++ b/force-app/main/default/classes/test/PhoneMaskTransformationTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/utils/LowerCaseTransformation.cls
+++ b/force-app/main/default/classes/utils/LowerCaseTransformation.cls
@@ -1,3 +1,10 @@
+/**
+ * @description       : 
+ * @author            : ChangeMeIn@UserSettingsUnder.SFDoc
+ * @group             : 
+ * @last modified on  : 10-24-2025
+ * @last modified by  : ChangeMeIn@UserSettingsUnder.SFDoc
+**/
 public with sharing class LowerCaseTransformation implements ITransformationRule {
 
     public String apply(Map<String, String> row, TransformationRule__c configRule) {
@@ -20,7 +27,7 @@ public with sharing class LowerCaseTransformation implements ITransformationRule
     public Boolean validate(Map<String, String> row, TransformationRule__c configRule) {
         // Vérifie si le champ est transformable  
         String targetField = configRule.FieldMapping__r.TargetField__c;
-        String value = row.get(targetField);
+
 
         if (String.isBlank(value)) {
             return false;

--- a/force-app/main/default/classes/utils/LowerCaseTransformation.cls
+++ b/force-app/main/default/classes/utils/LowerCaseTransformation.cls
@@ -27,7 +27,7 @@ public with sharing class LowerCaseTransformation implements ITransformationRule
     public Boolean validate(Map<String, String> row, TransformationRule__c configRule) {
         // Vérifie si le champ est transformable  
         String targetField = configRule.FieldMapping__r.TargetField__c;
-
+        String value = row.get(targetField);
 
         if (String.isBlank(value)) {
             return false;

--- a/force-app/main/default/classes/utils/PhoneMaskTransformation.cls
+++ b/force-app/main/default/classes/utils/PhoneMaskTransformation.cls
@@ -1,0 +1,279 @@
+/**
+ * @description       : 
+ * @author            : ChangeMeIn@UserSettingsUnder.SFDoc
+ * @group             : 
+ * @last modified on  : 10-24-2025
+ * @last modified by  : ChangeMeIn@UserSettingsUnder.SFDoc
+**/
+public with sharing class PhoneMaskTransformation implements ITransformationRule{
+      /**
+     * @description Applique la transformation de génération de numéro factice
+     * @param row Ligne de données CSV (non utilisée ici)
+     * @param configRule Configuration de la règle contenant le numéro dans Parameters__c
+     * @return String Numéro de téléphone factice avec indicatif préservé
+     */
+    public String apply(Map<String, String> row, TransformationRule__c configRule) {
+        try {
+            // Parser les paramètres JSON
+            // Format attendu: {"phone": "+221 78 999 99 99"}
+            Map<String, Object> params = (Map<String, Object>) JSON.deserializeUntyped(configRule.Parameters__c);
+            
+            String phoneNumber = (String) params.get('phone');
+            if (String.isBlank(phoneNumber)) {
+                return configRule.TargetValue__c != null ? configRule.TargetValue__c : '';
+            }
+
+            // Nettoyer le numéro (enlever espaces, tirets, parenthèses)
+            String cleanedPhone = cleanPhoneNumber(phoneNumber);
+
+            // Extraire l'indicatif pays
+            String countryCode = extractCountryCode(cleanedPhone);
+
+            // Générer le numéro factice
+            String dummyPhone = generateDummyPhone(countryCode, cleanedPhone);
+
+            return dummyPhone;
+
+        } catch (Exception e) {
+            System.debug(LoggingLevel.ERROR, 'Erreur génération dummy phone: ' + e.getMessage());
+            throw new DummyPhoneException('Erreur de génération: ' + e.getMessage());
+        }
+    }
+
+    /**
+     * @description Valide que le paramètre phone existe et contient une valeur
+     */
+    public Boolean validate(Map<String, String> row, TransformationRule__c configRule) {
+        try {
+            Map<String, Object> params = (Map<String, Object>) JSON.deserializeUntyped(configRule.Parameters__c);
+            String phoneNumber = (String) params.get('phone');
+            
+            return String.isNotBlank(phoneNumber);
+        } catch (Exception e) {
+            System.debug(LoggingLevel.ERROR, 'Erreur validation: ' + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * @description Nettoie le numéro de téléphone en enlevant les caractères non numériques
+     * sauf le + au début
+     */
+    private String cleanPhoneNumber(String phone) {
+        if (String.isBlank(phone)) {
+            return '';
+        }
+
+        String cleaned = phone.trim();
+        
+        // Si commence par 00, remplacer par +
+        if (cleaned.startsWith('00')) {
+            cleaned = '+' + cleaned.substring(2);
+        }
+
+        // Garder seulement + (au début), chiffres
+        String result = '';
+        for (Integer i = 0; i < cleaned.length(); i++) {
+            String char = cleaned.substring(i, i + 1);
+            if (char == '+' && i == 0) {
+                result += char;
+            } else if (char.isNumeric()) {
+                result += char;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * @description Extrait l'indicatif pays du numéro de téléphone
+     * @return String Indicatif pays avec le + (ex: "+33", "+221")
+     */
+    private String extractCountryCode(String cleanedPhone) {
+        if (String.isBlank(cleanedPhone)) {
+            return '';
+        }
+
+        // Si ne commence pas par +, pas d'indicatif détectable
+        if (!cleanedPhone.startsWith('+')) {
+            return '';
+        }
+
+        // Tester les indicatifs connus du plus long au plus court
+        // (pour éviter de confondre +1 avec +221 par exemple)
+        List<String> sortedCodes = new List<String>(COUNTRY_CODE_DIGITS.keySet());
+
+        // Trier par longueur décroissante
+        for (Integer i = 0; i < sortedCodes.size() - 1; i++) {
+            for (Integer j = i + 1; j < sortedCodes.size(); j++) {
+                if (sortedCodes[i].length() < sortedCodes[j].length()) {
+                    String temp = sortedCodes[i];
+                    sortedCodes[i] = sortedCodes[j];
+                    sortedCodes[j] = temp;
+                }
+            }
+        }
+
+        // Tester chaque indicatif connu
+        for (String code : sortedCodes) {
+            if (cleanedPhone.startsWith(code)) {
+                return code;
+            }
+        }
+
+        // Si aucun indicatif connu, essayer d'extraire les 2-4 premiers chiffres
+        // Format général: + suivi de 1 à 3 chiffres
+        if (cleanedPhone.length() >= 3) {
+            // Essayer 4 chiffres (ex: +221)
+            if (cleanedPhone.length() >= 5) {
+                String code4 = cleanedPhone.substring(0, 5);
+                if (code4.substring(1).isNumeric()) {
+                    return code4;
+                }
+            }
+            // Essayer 3 chiffres (ex: +33)
+            if (cleanedPhone.length() >= 4) {
+                String code3 = cleanedPhone.substring(0, 4);
+                if (code3.substring(1).isNumeric()) {
+                    return code3;
+                }
+            }
+            // Essayer 2 chiffres (ex: +1)
+            String code2 = cleanedPhone.substring(0, 3);
+            if (code2.substring(1).isNumeric()) {
+                return code2;
+            }
+        }
+
+        return '';
+    }
+
+
+
+    // validation
+    public Boolean validate(Map<String, String> row, TransformationRule__c configRule) {
+        // Vérifie si le champ est transformable
+        String targetField = configRule.FieldMapping__r.TargetField__c;
+        String value = (String) row.get(Constants.PHONE_VALUE);
+
+        String regex = '\\+?(\\d{1,3})?[-\\.\\s]?(\\(?\\d{3}\\)?[-\\.\\s]?)?(\\d[-\\.\\s]?){6,10}\\d$';
+
+
+        if (String.isBlank(value)) {
+            return false;
+        }
+
+        return Pattern.matches(regex,value);
+    }
+
+
+    /**
+     * @description Génère un numéro de téléphone factice avec l'indicatif pays
+    */
+    private String generateDummyPhone(String countryCode, String originalCleanedPhone) {
+        // Déterminer le nombre de chiffres à générer
+        Integer localDigits;
+
+        if (String.isNotBlank(countryCode) && COUNTRY_CODE_DIGITS.containsKey(countryCode)) {
+            // Utiliser le format standard du pays
+            localDigits = COUNTRY_CODE_DIGITS.get(countryCode);
+        } else if (String.isNotBlank(countryCode)) {
+            // Indicatif inconnu: calculer à partir du numéro original
+            localDigits = originalCleanedPhone.length() - countryCode.length();
+        } else {
+            // Pas d'indicatif: utiliser la longueur du numéro original
+            localDigits = originalCleanedPhone.length();
+        }
+
+        // Sécurité: minimum 6 chiffres, maximum 15
+        if (localDigits < 6) {
+            localDigits = 6;
+        }
+
+        if (localDigits > 15) {
+            localDigits = 15;
+        }
+
+        // Générer les chiffres aléatoires
+        String dummyLocal = generateRandomDigits(localDigits);
+
+        // Assembler le numéro final
+        if (String.isNotBlank(countryCode)) {
+            return countryCode + dummyLocal;
+        } else {
+            return dummyLocal;
+        }
+    }
+
+    /**
+     * @description Génère une chaîne de chiffres aléatoires
+     */
+    private String generateRandomDigits(Integer length) {
+        String result = '';
+        for (Integer i = 0; i < length; i++) {
+            // Générer un chiffre entre 0 et 9
+            Integer digit = Math.mod(Math.abs(Crypto.getRandomInteger()), 10);
+            result += String.valueOf(digit);
+        }
+        return result;
+    }
+
+    /**
+     * Map des indicatifs pays vers nombre de chiffres du numéro local
+    */
+    private static final Map<String, Integer> COUNTRY_CODE_DIGITS = new Map<String, Integer>{
+        '+1' => 10,      // USA, Canada
+        '+33' => 9,      // France
+        '+221' => 9,     // Sénégal
+        '+32' => 9,      // Belgique
+        '+41' => 9,      // Suisse
+        '+212' => 9,     // Maroc
+        '+225' => 10,    // Côte d'Ivoire
+        '+237' => 9,     // Cameroun
+        '+44' => 10,     // Royaume-Uni
+        '+49' => 10,     // Allemagne
+        '+34' => 9,      // Espagne
+        '+39' => 10,     // Italie
+        '+351' => 9,     // Portugal
+        '+213' => 9,     // Algérie
+        '+216' => 8,     // Tunisie
+        '+20' => 10,     // Égypte
+        '+91' => 10,     // Inde
+        '+86' => 11,     // Chine
+        '+81' => 10,     // Japon
+        '+82' => 10,     // Corée du Sud
+        '+852' => 8,     // Hong Kong
+        '+61' => 9,      // Australie
+        '+7' => 10,      // Russie
+        '+380' => 9,     // Ukraine
+        '+254' => 9,     // Kenya
+        '+233' => 9,     // Ghana
+        '+234' => 10,    // Nigeria
+        '+964' => 10,    // Irak
+        '+962' => 9,     // Jordanie
+        '+971' => 9,     // Émirats Arabes Unis
+        '+90' => 10,     // Turquie
+        '+48' => 9,      // Pologne
+        '+36' => 9,      // Hongrie
+        '+30' => 10,     // Grèce
+        '+358' => 9,     // Finlande
+        '+46' => 9,      // Suède
+        '+45' => 8,      // Danemark
+        '+420' => 9,     // République Tchèque
+        '+386' => 9,     // Slovénie
+        '+421' => 9,     // Slovaquie
+        '+373' => 8,     // Moldavie
+        '+56' => 9,      // Chili
+        '+52' => 10,     // Mexique
+        '+54' => 10,     // Argentine
+        '+55' => 10,     // Brésil
+        '+598' => 8,     // Uruguay
+        '+57' => 10,     // Colombie
+        '+351' => 9,     // Portugal
+        '+62' => 10,     // Indonésie
+        '+63' => 10,     // Philippines
+        '+84' => 9,      // Vietnam
+        '+977' => 10     // Népal
+    };
+
+}

--- a/force-app/main/default/classes/utils/PhoneMaskTransformation.cls
+++ b/force-app/main/default/classes/utils/PhoneMaskTransformation.cls
@@ -1,279 +1,128 @@
 /**
- * @description       : 
- * @author            : ChangeMeIn@UserSettingsUnder.SFDoc
- * @group             : 
- * @last modified on  : 10-24-2025
- * @last modified by  : ChangeMeIn@UserSettingsUnder.SFDoc
-**/
-public with sharing class PhoneMaskTransformation implements ITransformationRule{
-      /**
-     * @description Applique la transformation de génération de numéro factice
-     * @param row Ligne de données CSV (non utilisée ici)
-     * @param configRule Configuration de la règle contenant le numéro dans Parameters__c
-     * @return String Numéro de téléphone factice avec indicatif préservé
+ * @description Génère un numéro de téléphone factice tout en conservant l'indicatif pays.
+ * Implémente l'interface ITransformationRule utilisée dans le moteur de transformation.
+ */
+public with sharing class PhoneMaskTransformation implements ITransformationRule {
+
+    /**
+     * Applique la transformation : nettoie le numéro, extrait l’indicatif,
+     * et génère un faux numéro respectant la structure du pays.
+     *
+     * @param row Données CSV (ici, non utilisées)
+     * @param configRule Règle contenant le paramètre JSON {"phone": "<numéro>"}
+     * @return Numéro factice complet
      */
     public String apply(Map<String, String> row, TransformationRule__c configRule) {
         try {
-            // Parser les paramètres JSON
-            // Format attendu: {"phone": "+221 78 999 99 99"}
-            Map<String, Object> params = (Map<String, Object>) JSON.deserializeUntyped(configRule.Parameters__c);
-            
-            String phoneNumber = (String) params.get('phone');
-            if (String.isBlank(phoneNumber)) {
+            // Vérifie la présence de paramètres dans la règle
+            if (String.isBlank(configRule.Parameters__c)) {
                 return configRule.TargetValue__c != null ? configRule.TargetValue__c : '';
             }
 
-            // Nettoyer le numéro (enlever espaces, tirets, parenthèses)
-            String cleanedPhone = cleanPhoneNumber(phoneNumber);
-
-            // Extraire l'indicatif pays
-            String countryCode = extractCountryCode(cleanedPhone);
-
-            // Générer le numéro factice
-            String dummyPhone = generateDummyPhone(countryCode, cleanedPhone);
-
-            return dummyPhone;
-
-        } catch (Exception e) {
-            System.debug(LoggingLevel.ERROR, 'Erreur génération dummy phone: ' + e.getMessage());
-            throw new DummyPhoneException('Erreur de génération: ' + e.getMessage());
-        }
-    }
-
-    /**
-     * @description Valide que le paramètre phone existe et contient une valeur
-     */
-    public Boolean validate(Map<String, String> row, TransformationRule__c configRule) {
-        try {
+            // Récupère le numéro de téléphone depuis les paramètres JSON
             Map<String, Object> params = (Map<String, Object>) JSON.deserializeUntyped(configRule.Parameters__c);
             String phoneNumber = (String) params.get('phone');
-            
-            return String.isNotBlank(phoneNumber);
+
+            // Nettoie et reconstruit le numéro
+            String cleaned = cleanPhoneNumber(phoneNumber);
+            String countryCode = extractCountryCode(cleaned);
+            return generateDummyPhone(countryCode, cleaned);
+
         } catch (Exception e) {
-            System.debug(LoggingLevel.ERROR, 'Erreur validation: ' + e.getMessage());
-            return false;
+            // Capture toute erreur inattendue
+            System.debug(LoggingLevel.ERROR, 'Erreur génération dummy phone: ' + e.getMessage());
+            ErrorLogService.logException(e);
+            throw new ApplicationException('Erreur de génération: ' + e.getMessage());
         }
     }
 
     /**
-     * @description Nettoie le numéro de téléphone en enlevant les caractères non numériques
-     * sauf le + au début
+     * Valide qu’un numéro est au bon format avant transformation.
+     *
+     * @param row Données d’entrée contenant le numéro
+     * @param configRule Règle de transformation
+     * @return true si le format correspond à un numéro valide
      */
-    private String cleanPhoneNumber(String phone) {
-        if (String.isBlank(phone)) {
-            return '';
-        }
-
-        String cleaned = phone.trim();
-        
-        // Si commence par 00, remplacer par +
-        if (cleaned.startsWith('00')) {
-            cleaned = '+' + cleaned.substring(2);
-        }
-
-        // Garder seulement + (au début), chiffres
-        String result = '';
-        for (Integer i = 0; i < cleaned.length(); i++) {
-            String char = cleaned.substring(i, i + 1);
-            if (char == '+' && i == 0) {
-                result += char;
-            } else if (char.isNumeric()) {
-                result += char;
-            }
-        }
-
-        return result;
-    }
-
-    /**
-     * @description Extrait l'indicatif pays du numéro de téléphone
-     * @return String Indicatif pays avec le + (ex: "+33", "+221")
-     */
-    private String extractCountryCode(String cleanedPhone) {
-        if (String.isBlank(cleanedPhone)) {
-            return '';
-        }
-
-        // Si ne commence pas par +, pas d'indicatif détectable
-        if (!cleanedPhone.startsWith('+')) {
-            return '';
-        }
-
-        // Tester les indicatifs connus du plus long au plus court
-        // (pour éviter de confondre +1 avec +221 par exemple)
-        List<String> sortedCodes = new List<String>(COUNTRY_CODE_DIGITS.keySet());
-
-        // Trier par longueur décroissante
-        for (Integer i = 0; i < sortedCodes.size() - 1; i++) {
-            for (Integer j = i + 1; j < sortedCodes.size(); j++) {
-                if (sortedCodes[i].length() < sortedCodes[j].length()) {
-                    String temp = sortedCodes[i];
-                    sortedCodes[i] = sortedCodes[j];
-                    sortedCodes[j] = temp;
-                }
-            }
-        }
-
-        // Tester chaque indicatif connu
-        for (String code : sortedCodes) {
-            if (cleanedPhone.startsWith(code)) {
-                return code;
-            }
-        }
-
-        // Si aucun indicatif connu, essayer d'extraire les 2-4 premiers chiffres
-        // Format général: + suivi de 1 à 3 chiffres
-        if (cleanedPhone.length() >= 3) {
-            // Essayer 4 chiffres (ex: +221)
-            if (cleanedPhone.length() >= 5) {
-                String code4 = cleanedPhone.substring(0, 5);
-                if (code4.substring(1).isNumeric()) {
-                    return code4;
-                }
-            }
-            // Essayer 3 chiffres (ex: +33)
-            if (cleanedPhone.length() >= 4) {
-                String code3 = cleanedPhone.substring(0, 4);
-                if (code3.substring(1).isNumeric()) {
-                    return code3;
-                }
-            }
-            // Essayer 2 chiffres (ex: +1)
-            String code2 = cleanedPhone.substring(0, 3);
-            if (code2.substring(1).isNumeric()) {
-                return code2;
-            }
-        }
-
-        return '';
-    }
-
-
-
-    // validation
     public Boolean validate(Map<String, String> row, TransformationRule__c configRule) {
-        // Vérifie si le champ est transformable
-        String targetField = configRule.FieldMapping__r.TargetField__c;
-        String value = (String) row.get(Constants.PHONE_VALUE);
-
-        String regex = '\\+?(\\d{1,3})?[-\\.\\s]?(\\(?\\d{3}\\)?[-\\.\\s]?)?(\\d[-\\.\\s]?){6,10}\\d$';
-
-
+        String value = row.get(Constants.PHONE_VALUE);
         if (String.isBlank(value)) {
             return false;
         }
 
-        return Pattern.matches(regex,value);
+        // Expression régulière basique de validation de numéro international
+        String regex = '\\+?(\\d{1,3})?[-\\.\\s]?(\\(?\\d{3}\\)?[-\\.\\s]?)?(\\d[-\\.\\s]?){6,10}\\d$';
+        return Pattern.matches(regex, value);
     }
 
+    /**
+     * Supprime les caractères inutiles d’un numéro de téléphone :
+     * espaces, tirets, parenthèses. Préserve le + au début.
+     */
+    private String cleanPhoneNumber(String phone) {
+        phone = phone.trim();
+
+        // Convertit un numéro commençant par "00" en format international "+"
+        if (phone.startsWith('00')) {
+            phone = '+' + phone.substring(2);
+        }
+
+        List<String> result = new List<String>();
+
+        // Conserve uniquement les chiffres et le + initial
+        for (Integer i = 0; i < phone.length(); i++) {
+            String c = phone.substring(i, i + 1);
+            if ((c == '+' && i == 0) || c.isNumeric()) {
+                result.add(c);
+            }
+        }
+
+        return result.toString();
+    }
 
     /**
-     * @description Génère un numéro de téléphone factice avec l'indicatif pays
-    */
-    private String generateDummyPhone(String countryCode, String originalCleanedPhone) {
-        // Déterminer le nombre de chiffres à générer
+     * Extrait l’indicatif pays à partir du numéro nettoyé.
+     * @return Exemple : "+221" ou "+33"
+     */
+    private String extractCountryCode(String phone) {
+        if (!phone.startsWith('+')) {
+            return '';
+        }
+
+        // Compare le début du numéro à la liste connue des indicatifs
+        for (String code : Constants.COUNTRY_CODE_DIGITS.keySet()) {
+            if (phone.startsWith(code)) {
+                return code;
+            }
+        }
+
+        // Aucun indicatif reconnu
+        return '';
+    }
+
+    /**
+     * Génère un numéro local aléatoire en fonction du pays.
+     * @param countryCode Indicatif pays (ex: +221)
+     * @param cleaned Numéro d’origine nettoyé
+     * @return Numéro complet factice
+     */
+    private String generateDummyPhone(String countryCode, String cleaned) {
         Integer localDigits;
 
-        if (String.isNotBlank(countryCode) && COUNTRY_CODE_DIGITS.containsKey(countryCode)) {
-            // Utiliser le format standard du pays
-            localDigits = COUNTRY_CODE_DIGITS.get(countryCode);
-        } else if (String.isNotBlank(countryCode)) {
-            // Indicatif inconnu: calculer à partir du numéro original
-            localDigits = originalCleanedPhone.length() - countryCode.length();
+        // Détermine le nombre de chiffres à générer
+        if (Constants.COUNTRY_CODE_DIGITS.containsKey(countryCode)) {
+            localDigits = Constants.COUNTRY_CODE_DIGITS.get(countryCode);
         } else {
-            // Pas d'indicatif: utiliser la longueur du numéro original
-            localDigits = originalCleanedPhone.length();
+            localDigits = Math.max(6, Math.min(cleaned.length() - countryCode.length(), 15));
         }
 
-        // Sécurité: minimum 6 chiffres, maximum 15
-        if (localDigits < 6) {
-            localDigits = 6;
+        // Génération du bloc local aléatoire
+        List<String> dummy = new List<String>();
+        for (Integer i = 0; i < localDigits; i++) {
+            dummy.add(String.valueOf(Math.mod(Math.abs(Crypto.getRandomInteger()), 10)));
         }
 
-        if (localDigits > 15) {
-            localDigits = 15;
-        }
-
-        // Générer les chiffres aléatoires
-        String dummyLocal = generateRandomDigits(localDigits);
-
-        // Assembler le numéro final
-        if (String.isNotBlank(countryCode)) {
-            return countryCode + dummyLocal;
-        } else {
-            return dummyLocal;
-        }
+        // Concatène l’indicatif s’il existe
+        return String.isNotBlank(countryCode) ? countryCode + dummy.toString() : dummy.toString();
     }
-
-    /**
-     * @description Génère une chaîne de chiffres aléatoires
-     */
-    private String generateRandomDigits(Integer length) {
-        String result = '';
-        for (Integer i = 0; i < length; i++) {
-            // Générer un chiffre entre 0 et 9
-            Integer digit = Math.mod(Math.abs(Crypto.getRandomInteger()), 10);
-            result += String.valueOf(digit);
-        }
-        return result;
-    }
-
-    /**
-     * Map des indicatifs pays vers nombre de chiffres du numéro local
-    */
-    private static final Map<String, Integer> COUNTRY_CODE_DIGITS = new Map<String, Integer>{
-        '+1' => 10,      // USA, Canada
-        '+33' => 9,      // France
-        '+221' => 9,     // Sénégal
-        '+32' => 9,      // Belgique
-        '+41' => 9,      // Suisse
-        '+212' => 9,     // Maroc
-        '+225' => 10,    // Côte d'Ivoire
-        '+237' => 9,     // Cameroun
-        '+44' => 10,     // Royaume-Uni
-        '+49' => 10,     // Allemagne
-        '+34' => 9,      // Espagne
-        '+39' => 10,     // Italie
-        '+351' => 9,     // Portugal
-        '+213' => 9,     // Algérie
-        '+216' => 8,     // Tunisie
-        '+20' => 10,     // Égypte
-        '+91' => 10,     // Inde
-        '+86' => 11,     // Chine
-        '+81' => 10,     // Japon
-        '+82' => 10,     // Corée du Sud
-        '+852' => 8,     // Hong Kong
-        '+61' => 9,      // Australie
-        '+7' => 10,      // Russie
-        '+380' => 9,     // Ukraine
-        '+254' => 9,     // Kenya
-        '+233' => 9,     // Ghana
-        '+234' => 10,    // Nigeria
-        '+964' => 10,    // Irak
-        '+962' => 9,     // Jordanie
-        '+971' => 9,     // Émirats Arabes Unis
-        '+90' => 10,     // Turquie
-        '+48' => 9,      // Pologne
-        '+36' => 9,      // Hongrie
-        '+30' => 10,     // Grèce
-        '+358' => 9,     // Finlande
-        '+46' => 9,      // Suède
-        '+45' => 8,      // Danemark
-        '+420' => 9,     // République Tchèque
-        '+386' => 9,     // Slovénie
-        '+421' => 9,     // Slovaquie
-        '+373' => 8,     // Moldavie
-        '+56' => 9,      // Chili
-        '+52' => 10,     // Mexique
-        '+54' => 10,     // Argentine
-        '+55' => 10,     // Brésil
-        '+598' => 8,     // Uruguay
-        '+57' => 10,     // Colombie
-        '+351' => 9,     // Portugal
-        '+62' => 10,     // Indonésie
-        '+63' => 10,     // Philippines
-        '+84' => 9,      // Vietnam
-        '+977' => 10     // Népal
-    };
 
 }

--- a/force-app/main/default/classes/utils/PhoneMaskTransformation.cls-meta.xml
+++ b/force-app/main/default/classes/utils/PhoneMaskTransformation.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/utils/TransformationUtils.cls
+++ b/force-app/main/default/classes/utils/TransformationUtils.cls
@@ -2,7 +2,7 @@
  * @description       : 
  * @author            : ChangeMeIn@UserSettingsUnder.SFDoc
  * @group             : 
- * @last modified on  : 10-20-2025
+ * @last modified on  : 10-24-2025
  * @last modified by  : ChangeMeIn@UserSettingsUnder.SFDoc
 **/
 public with sharing class TransformationUtils {
@@ -14,6 +14,8 @@ public with sharing class TransformationUtils {
             return new LowerCaseTransformation();
         }else if(rule.RuleType__c == 'UpperCaseTransformation'){
             return new UpperCaseTransformation();
+        }else if(rule.RuleType__c =='PhoneMask'){
+            return new PhoneMaskTransformation();
         }
         return null;
     }


### PR DESCRIPTION
## Phone Mask Transformation

### Description
La classe `Phone Mask` permet de ** génère un numéro de téléphone factice tout en conservant l'indicatif pays.
 Dummy Phone Number
---

### Traitements effectués
- Modification des classes  , Constants avec l'ajout d'une méthode permettant récupérées les indicatifs   et TransformationUtils
- Création de la classe `PhoneMaskTransformation` implémentant `ITransformationRule`
- Création de la classe de test `PhoneMaskTransformationTest`
 

---
 

 
