### PR TITLE
Fix/integrate-datasource-source

### DIFF
--- a/force-app/main/default/lwc/dataSourceSelector/dataSourceSelector.html
+++ b/force-app/main/default/lwc/dataSourceSelector/dataSourceSelector.html
@@ -2,7 +2,7 @@
   @description       : 
   @author            : ChangeMeIn@UserSettingsUnder.SFDoc
   @group             : 
-  @last modified on  : 11-04-2025
+  @last modified on  : 11-10-2025
   @last modified by  : ChangeMeIn@UserSettingsUnder.SFDoc
 -->
 <template>

--- a/force-app/main/default/lwc/dataSourceSelector/dataSourceSelector.js
+++ b/force-app/main/default/lwc/dataSourceSelector/dataSourceSelector.js
@@ -1,6 +1,47 @@
 import { LightningElement, api } from "lwc";
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 export default class DataSourceSelector extends LightningElement {
+    //data source selector card's parameters for file Upload
+  uploadTitle = "File Upload";
+  uploadSubtitle = "Import from CSV or Excel files";
+  uploadTextButton = "Choose File Upload";
+  uploadContents = [
+    {
+      Id: 1,
+      Name: "Support for CSV and Excel formats"
+    },
+    {
+      Id: 2,
+      Name: "Automatic delimiter detection"
+    },
+    {
+      Id: 3,
+      Name: "File preview and validation"
+    }
+  ];
+
+  //data source selector card's parameters for query builder
+   queryContents = [
+    {
+      Id: 1,
+      Name: "Visual query builder interface"
+    },
+    {
+      Id: 2,
+      Name: "Real-time query validation"
+    },
+    {
+      Id: 3,
+      Name: "Preview query results"
+    }
+  ];
+
+  queryTitle = "Salesforce Query";
+  querySubTitle = "Import from Salesforce using SOQL";
+
+
+  isUpload = true; // check if upload card
+  isNotUpload = ! true;
   currentStep = 2;
   selectedSource = null; // "CSV" | "SOQL" | null
 

--- a/force-app/main/default/lwc/dataSourceSelector/dataSourceSelector.js
+++ b/force-app/main/default/lwc/dataSourceSelector/dataSourceSelector.js
@@ -1,7 +1,7 @@
 import { LightningElement, api } from "lwc";
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 export default class DataSourceSelector extends LightningElement {
-    //data source selector card's parameters for file Upload
+    //data source selector card's parameters for file Upload parameter
   uploadTitle = "File Upload";
   uploadSubtitle = "Import from CSV or Excel files";
   uploadTextButton = "Choose File Upload";
@@ -20,7 +20,7 @@ export default class DataSourceSelector extends LightningElement {
     }
   ];
 
-  //data source selector card's parameters for query builder
+  //data source selector card's parameters for query builder parameters
    queryContents = [
     {
       Id: 1,


### PR DESCRIPTION
## Intégration des variables manquantes pour la sélection de source de données

### Description
Cette PR ajoute les variables nécessaires dans `dataSourceSelect` afin de configurer correctement les sections *File Upload* et *Salesforce Query*.  
Les données manquantes identifiées ont été réintégrées dans une nouvelle branche, sans modification des méthodes existantes.

### Changements principaux
- Ajout des variables :
  - `uploadTitle`
  - `uploadSubtitle`
  - `uploadTextButton`
  - `uploadContents`
  - `queryTitle`
  - `querySubTitle`
  - `queryContents`
- Transmission de ces données au composant enfant `DataSourceSelectCard` pour l’affichage.
- Aucun changement apporté à la logique métier ou aux méthodes existantes.

### Impact
La sélection de la source de données fonctionne correctement dans les scratch orgs, avec l’affichage attendu pour les modes *Upload* et *Query*.


### Tests
Vérification effectuée après déploiement dans un scratch org afin de confirmer la bonne intégration des données.
<img width="952" height="506" alt="image" src="https://github.com/user-attachments/assets/dd5ac31d-001e-4e09-9e47-8bf3e921803a" />
