### PR TITLE
fix:Save project & refresh rule's list after registered on transformation page

### DIFF
--- a/force-app/main/default/classes/repositories/TransformationRepository.cls
+++ b/force-app/main/default/classes/repositories/TransformationRepository.cls
@@ -2,8 +2,9 @@
  * @description       : 
  * @author            : ChangeMeIn@UserSettingsUnder.SFDoc
  * @group             : 
- * @last modified on  : 11-28-2025
- * @last modified by  : ChangeMeIn@UserSettingsUnder.SFDoc
+ * @last modified on  : 12-30-2025
+ * @last modified by  : Mouhamed NIANG
+ * Modification: ajout  du champs FieldMapping__r.SourceColumn__c à la méthode  getRulesByProjectId
 **/
 public with sharing class TransformationRepository {
 
@@ -24,7 +25,7 @@ public with sharing class TransformationRepository {
         if (SecurityUtils.isAccessible(Schema.TransformationRule__c.SObjectType)) {
             try {
                 return [SELECT Id, RuleType__c, Parameters__c, FieldMapping__c, 
-                        FieldMapping__r.TargetField__c, SourceFields__c, TargetValue__c, Order__c
+                        FieldMapping__r.TargetField__c, SourceFields__c, TargetValue__c, Order__c,FieldMapping__r.SourceColumn__c
                         FROM TransformationRule__c 
                         WHERE Project__c = :projectId 
                         /* WITH SECURITY_ENFORCED  */

--- a/force-app/main/default/lwc/projectFormComponent/projectFormComponent.js
+++ b/force-app/main/default/lwc/projectFormComponent/projectFormComponent.js
@@ -1,3 +1,9 @@
+/**
+ * 
+ * @Last Modification Date: 30-12-2025
+ * @Modification: changement composant c-project-form-component du méthode projectnamechange -> namechange
+ * Changement composant c-project-form du méthode targetobjectchange -> targetchange
+ */
 import { LightningElement, api, track } from "lwc";
 
 //import methods from Controller
@@ -41,7 +47,7 @@ export default class ProjectFormComponent extends LightningElement {
   //Evénement portant sur la mise à jour du nom du projet
   handleProjectNameChange(event) {
     this.dispatchEvent(
-      new CustomEvent("namechange", { detail: event.target.value })
+      new CustomEvent("projectnamechange", { detail: event.target.value })
     );
   }
 
@@ -57,7 +63,7 @@ export default class ProjectFormComponent extends LightningElement {
   //  de l'événement portant sur la mise à jour de l'attribut target object
   handleTargetObjectChange(event) {
     this.dispatchEvent(
-      new CustomEvent("targetchange", { detail: event.target.value })
+      new CustomEvent("targetobjectchange", { detail: event.target.value })
     );
   }
 

--- a/force-app/main/default/lwc/transformationPage/transformationPage.js
+++ b/force-app/main/default/lwc/transformationPage/transformationPage.js
@@ -32,14 +32,13 @@ export default class TransformationPage extends LightningElement {
 
         this.wiredTransformationResults = data.map(rule => {
             const iconConfig = this.getIconConfig(rule.RuleType__c);
-            const category = this.getCategory(rule.RuleType__c);
-
+            const category = this.getCategory(rule.RuleType__c); 
             return {
                 id: rule.Id,
                 rule: rule.RuleType__c,
                 category,
                 displayTitle: iconConfig.title ?? rule.RuleType__c,
-                displaySubtitle: `Source : ${rule.FieldMapping__r?.SourceColumn__c ?? 'Unknown Field'} → ${rule.FieldMapping__r?.TargetField__c ?? 'Unknown Field'}`,
+                displaySubtitle: `Source : ${rule.FieldMapping__r.SourceColumn__c ?? 'Unknown Field'} → ${rule.FieldMapping__r?.TargetField__c ?? 'Unknown Field'}`,
                 iconName: iconConfig.icon,
                 iconBoxClass: iconConfig.boxClass,
                 headIconClass: iconConfig.iconClass,
@@ -89,7 +88,7 @@ export default class TransformationPage extends LightningElement {
         label: 'Add New rule',
         mappingId: event.detail.mappingId,
         mapping: event.detail.mapping,
-        onrefresh: () => this.refreshTransformations() // refresh list rule
+        onrefresh: async() => await refreshApex(this._wiredResult) // refresh list rule
       });
 
       this.transformationId = result;

--- a/force-app/main/default/lwc/transformationSaveModal/transformationSaveModal.js
+++ b/force-app/main/default/lwc/transformationSaveModal/transformationSaveModal.js
@@ -1,3 +1,8 @@
+/**
+ * @Last Modification: 30-12-2025
+ * @Last Modification By : Mouhamed NIANG
+ * ReadOnly Field Mapping SourceField -> TargetField
+ */
 import { wire, api, track } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent'; 
 import TRANSFORMATION_OBJECT from '@salesforce/schema/TransformationRule__c'; 
@@ -44,7 +49,7 @@ export default class TransformationSaveModal extends LightningModal {
     // Handlers UI
     // ------------------------
     get mappingInfo(){
-        return `${this.mapping.version} -> ${this.mapping.sourceColumn} `
+        return ` ${this.mapping.sourceColumn} -> ${this.mapping.targetField} `
     }
 
 
@@ -174,6 +179,7 @@ export default class TransformationSaveModal extends LightningModal {
            
             const rule = await createRule(payload);
             const ruleId = rule.Id; 
+            this.dispatchEvent(new CustomEvent('refresh')); //refresh the rules list
             
             this.close(ruleId);
             
@@ -299,7 +305,7 @@ export default class TransformationSaveModal extends LightningModal {
             
             // Options pour le combobox "Mapping Field"
             this.fieldMappingOptions = data.map(m => ({
-                label: `${m.targetField} → ${m.sourceField || m.version}`,
+                label: `${m.targetField} → ${m.sourceField || m.targetField }`,
                 value: m.id
             }));
             


### PR DESCRIPTION
# Project Import & Transformation Salesforce
Cette PR vise à apporter des correctifs sur le INT 

## Fonctionnalités principales corrigées
[demo ici]( https://www.loom.com/share/faedc7ac0b6842e391664109f9d73e3e)
- **Project Save Form** : Fix création des projets d'import . 
- **Transformation Rules** :  
  - Rafraîchissement après création de transformation.  
  -  Affichage du champs FieldMapping.Source Column__c dans la carte des transformations
## Modifications récentes

- Ajout de l'événement `refresh` pour rafraîchir la page après la sauvegarde dans `TransformationSaveForm` méthode `handleSaveTransformation`.
- Modification de la méthode getRulesByProjectId avec l'ajout champs `FieldMapping.SourceColumn__c` dans `TransformationRepository`  
- `ProjectFormComponent.js`  Remplace des évenements émis vers le parent `mainComponent.js`
    - `targetchange` en `targetobjectchange`  de la méthode handleTargetObjectChange
    -  `namechange` en `projectnamechange` de la méthode handleProjectNameChange
