### PR TITLE
fix(ui): resolve transformation update cache, modal cancellation, and…

### DIFF
--- a/force-app/main/default/lwc/transformationPage/transformationPage.js
+++ b/force-app/main/default/lwc/transformationPage/transformationPage.js
@@ -127,13 +127,7 @@ export default class TransformationPage extends LightningElement {
         if (result.success) {
             await refreshApex(this._wiredResult);
             this.showToast('Success', result.message, 'success');
-          } else {
-            this.showToast(
-              result.variant === 'error' ? 'Error' : 'Warning',
-              result.message || 'Update cancelled',
-              result.variant || 'warning'
-            );
-          }
+        }
     } catch (error) {
       console.error('Erreur lors de la création:', error);
          this.showToast(
@@ -267,9 +261,14 @@ export default class TransformationPage extends LightningElement {
   async handleEditTransformation(event) {
     try {
       const existingRuleId = event.detail.ruleId; 
-      console.log('existingRuleId', existingRuleId);
+      const ruleType = this._wiredResult.data.find(rule => rule.Id === existingRuleId)?.RuleType__c; 
+    
+      // On adapte la taille dynamiquement
+      const modalSize = (ruleType === 'Concatenation' || ruleType === 'BooleanTransformation') 
+                      ? 'large' 
+                      : 'small';
       const result = await TransformationModal.open({
-        size: 'large',
+        size: modalSize,
         description: 'Ce modal permet la  modification de règle transformation avec les mappings',
         projectId: this.projectId,
         targetObject: this.selectedProject?.data?.TargetObject__c,
@@ -279,7 +278,7 @@ export default class TransformationPage extends LightningElement {
         existingRuleId: existingRuleId
       });
 
-      if (!result) return;
+      if (!result || result === 'okay') return;
 
       if (result.success) {
         await refreshApex(this._wiredResult);
@@ -289,13 +288,13 @@ export default class TransformationPage extends LightningElement {
            result.message,
           'success'
         );
-      } else {
-        this.showToast(
-          'Warning',
-          result.message,
-          result.variant || 'warning'
-        );
-      }
+      }else if (result.message) {
+            this.showToast(
+                'Warning',
+                result.message,
+                result.variant || 'warning'
+            );
+        }
     } catch (error) {
       console.error('Erreur lors de la création:', error);
       this.showToast(

--- a/force-app/main/default/lwc/transformationPage/transformationPage.js
+++ b/force-app/main/default/lwc/transformationPage/transformationPage.js
@@ -111,6 +111,7 @@ export default class TransformationPage extends LightningElement {
   // Ouverture du modal pour ajouter  une nouvelle transformation
   async handleAddTransformation(event) {  
     try {
+      this.refreshTransformations();
       const result = await TransformationModal.open({ 
         size: 'medium',
         description: 'Ce modal permet la création  de nouvelle règle transformation avec les mappings',

--- a/force-app/main/default/lwc/transformationSaveModal/transformationSaveModal.js
+++ b/force-app/main/default/lwc/transformationSaveModal/transformationSaveModal.js
@@ -9,6 +9,7 @@
  */
 import { wire, api, track } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent'; 
+import { refreshApex } from '@salesforce/apex';
 import TRANSFORMATION_OBJECT from '@salesforce/schema/TransformationRule__c'; 
 import LightningModal from 'lightning/modal';
 import RULE_TYPE_FIELD from '@salesforce/schema/TransformationRule__c.RuleType__c';
@@ -96,18 +97,7 @@ export default class TransformationSaveModal extends LightningModal {
             console.log('Fields chargés:', this.fields);
 
             // Si les options de picklist sont déjà chargées, assigner le ruleType maintenant
-            if (this.ruleTypeOptions.length > 0 && !this.hasLoadedRule) {
-                this.hasLoadedRule = true;
-            
-                const ruleTypeFromDB = data.RuleType__c;
-                console.log('Rule Type from DB:', ruleTypeFromDB);
-
-                const match = this.ruleTypeOptions.find(opt => {
-                    return opt.value === ruleTypeFromDB || opt.label === ruleTypeFromDB;
-                });
-           
-                this.ruleType = match ? match.value : ruleTypeFromDB;
-            }
+            this.syncRuleType(data, this.ruleTypeOptions, this.hasLoadedRule);
     
             this.getFieldsForBooleanTransformation(data, params);
             
@@ -118,6 +108,24 @@ export default class TransformationSaveModal extends LightningModal {
         if (error) {
             console.error('Erreur chargement rule', error);
             this.toastErr('Impossible de charger la règle');
+        }
+    }
+
+    // Méthode pour synchroniser le RuleType une fois que les options sont chargées
+    syncRuleType(existingRule, ruleTypeOptions, hasLoadedRule) {
+        // On ne procède que si on a TOUTES les billes en main
+        if (existingRule && ruleTypeOptions.length > 0 && !hasLoadedRule) {
+            const ruleTypeFromDB = existingRule.RuleType__c;
+            
+            const match = ruleTypeOptions.find(opt => 
+                opt.value === ruleTypeFromDB || opt.label === ruleTypeFromDB
+            );
+
+            if (match) {
+                this.ruleType = match.value;
+                hasLoadedRule = true; // On marque comme chargé pour éviter les boucles
+                console.log('Sync RuleType Success:', this.ruleType);
+            }
         }
     }
 
@@ -270,7 +278,7 @@ export default class TransformationSaveModal extends LightningModal {
  
     handleCancel() {
         this.resetState();
-        this.close({ success: false });
+        this.close();
     }
 
     disconnectedCallback() {
@@ -278,44 +286,43 @@ export default class TransformationSaveModal extends LightningModal {
         this.resetState();
     }
 
+     // Méthode experte pour réinitialiser le composant
+    @api
     resetState() {
-        // Réinitialiser toutes les propriétés
-        this.ruleType = '';
+        // 1. Réinitialisation des états logiques
+        this.ruleType = undefined;
         this.existingRule = null;
         this.isEdit = false;
         this.hasLoadedRule = false;
         this.fields = [];
-        this.targetFields = [];
-        this.existingRuleId = null;
         this.selectedColumns = [];
         this.isBooleanTransformation = false;
         this.booleanValue = false;
         this.separator = '';
         this.targetValue = '';
         this.mappingId = null;
-        this.parameters = '{}';
         this.domain = '';
         this.phone = '';
-        
+
+        // Réinitialisation de l'objet mapping
         this.mapping = {
             sourceColumn: '',
             targetField: ''
         };
 
-        // Reset UI
-        Promise.resolve().then(() => {
-            const inputs = this.template.querySelectorAll(".rounded-input");
-            if (inputs && inputs.length > 0) {
-                inputs.forEach((input) => {
-                    input.value = "";
-                });
-            }
-        
-            const comboboxes = this.template.querySelectorAll("lightning-combobox");
-            if (comboboxes && comboboxes.length > 0) {
-                comboboxes.forEach((combo) => {
-                    combo.value = null;
-                });
+        // 2. Nettoyage visuel des composants Lightning
+        // On utilise querySelectorAll pour vider les valeurs et effacer les messages d'erreur
+        const inputFields = [
+            ...this.template.querySelectorAll('lightning-input'),
+            ...this.template.querySelectorAll('lightning-combobox'),
+            ...this.template.querySelectorAll('lightning-dual-listbox')
+        ];
+
+        inputFields.forEach(field => {
+            if (field.reportValidity) {
+                field.value = field.tagName === 'LIGHTNING-DUAL-LISTBOX' ? [] : undefined;
+                field.setCustomValidity(''); // Supprime les messages d'erreur personnalisés
+                field.reportValidity(); // Rafraîchit l'état visuel
             }
         });
     }
@@ -484,6 +491,9 @@ export default class TransformationSaveModal extends LightningModal {
             
             const savedRuleId = this.existingRuleId;
             await updateRule(payload);
+
+            // RAFRAÎCHISSEMENT DU CACHE ICI
+            await refreshApex(this.wiredRuleResult);
 
             this.resetState();
 

--- a/force-app/main/default/lwc/transformationSaveModal/transformationSaveModal.js
+++ b/force-app/main/default/lwc/transformationSaveModal/transformationSaveModal.js
@@ -47,6 +47,8 @@ export default class TransformationSaveModal extends LightningModal {
     fieldMappingOptions = [];
     targetFieldOptions = [];
 
+    wiredResultToRefresh;
+
     separatorOptions = [
         { label: 'Tab', value: '\t' },
         { label: 'Comma', value: ',' },
@@ -60,7 +62,10 @@ export default class TransformationSaveModal extends LightningModal {
     @api existingRuleId;
 
     @wire(getRuleById, { ruleId: '$existingRuleId' })
-    wiredExistingRuleById({ data, error }) {
+    wiredExistingRuleById(result) {
+        this.wiredResultToRefresh = result;
+        const { data, error } = result;
+
         if (data) {
             this.isEdit = true;
             this.existingRule = data;
@@ -97,7 +102,7 @@ export default class TransformationSaveModal extends LightningModal {
             console.log('Fields chargés:', this.fields);
 
             // Si les options de picklist sont déjà chargées, assigner le ruleType maintenant
-            this.syncRuleType(data, this.ruleTypeOptions, this.hasLoadedRule);
+            this.syncRuleType(data);
     
             this.getFieldsForBooleanTransformation(data, params);
             
@@ -112,18 +117,18 @@ export default class TransformationSaveModal extends LightningModal {
     }
 
     // Méthode pour synchroniser le RuleType une fois que les options sont chargées
-    syncRuleType(existingRule, ruleTypeOptions, hasLoadedRule) {
+    syncRuleType(existingRule) {
         // On ne procède que si on a TOUTES les billes en main
-        if (existingRule && ruleTypeOptions.length > 0 && !hasLoadedRule) {
+        if (existingRule && this.ruleTypeOptions.length > 0 && !this.hasLoadedRule) {
             const ruleTypeFromDB = existingRule.RuleType__c;
             
-            const match = ruleTypeOptions.find(opt => 
+            const match = this.ruleTypeOptions.find(opt => 
                 opt.value === ruleTypeFromDB || opt.label === ruleTypeFromDB
             );
 
             if (match) {
                 this.ruleType = match.value;
-                hasLoadedRule = true; // On marque comme chargé pour éviter les boucles
+                this.hasLoadedRule = true; // On marque comme chargé pour éviter les boucles
                 console.log('Sync RuleType Success:', this.ruleType);
             }
         }
@@ -185,7 +190,7 @@ export default class TransformationSaveModal extends LightningModal {
         
         // Trouver le label correspondant à la valeur
         const option = this.ruleTypeOptions.find(opt => opt.label === this.existingRule?.RuleType__c);
-        return option ? option.label : this.ruleType;
+        return option ? option.label : '';
     }
 
     get modalLabel() {
@@ -493,7 +498,7 @@ export default class TransformationSaveModal extends LightningModal {
             await updateRule(payload);
 
             // RAFRAÎCHISSEMENT DU CACHE ICI
-            await refreshApex(this.wiredRuleResult);
+            await refreshApex(this.wiredResultToRefresh);
 
             this.resetState();
 


### PR DESCRIPTION
## Summary
This PR addresses critical synchronization and UX issues within the transformation management module. It ensures data consistency between the UI and Salesforce database while stabilizing the modal interaction flow.
## [demo here](https://www.loom.com/share/9dae9b258372431b8c1746584a84c71d)

###  Changes
- **Cache Management:** Integrated `refreshApex` in `TransformationPage.js` to invalidate stale data after a successful DML update .
- **Race Condition Fix:** Implemented a synchronization pattern in `transformationSaveModal.js` to ensure the `ruleType` is correctly assigned even when Apex data arrives before Picklist options.
- **Modal Logic:** Corrected the `handleCancel` method by fixing the issue related to warning message after close modal 
- **Error Handling:** Enhanced `handleEditTransformation` to gracefully handle different modal close scenarios.
###  Updated files
- transformationSaveModal.js
-  transformationPage.js