### PR TITLE
Feature/IM-TR-004 Traduction formulaires projet

### DIFF
--- a/config/destructive/destructiveChanges.xml
+++ b/config/destructive/destructiveChanges.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
-  <types>
-    <members>ValidationQueueable</members>
-    <members>ValidationQueueableTest</members>
-    <members>ImportQueueable</members>
-    <members>ImportQueueableTest</members>
-    <members>ValidationService</members>
-    <members>ValidationServiceTest</members>
-    <name>ApexClass</name>
-  </types>
   <version>58.0</version>
 </Package>

--- a/config/destructive/destructiveChanges.xml
+++ b/config/destructive/destructiveChanges.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<<<<<<< feature/traduction-formulaires-projet
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
-=======
-<Package xmlns="http://soap.sforce.com/2006/04/metadata"> 
->>>>>>> develop
   <version>58.0</version>
 </Package>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+    <!-- Project form  -->
+    <labels>
+        <fullName>ProjectForm_Title</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Title for projection information section</shortDescription>
+        <value>New Project</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Subtitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>SubTitle for projection information section</shortDescription>
+        <value>Set up your data import project with target object and configuration</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Info_Section_Label</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Section's Project Information</shortDescription>
+        <value>Project Information</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Target_Section_Label</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Section's title Target Object Configuration</shortDescription>
+        <value>Target Object Configuration</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Name</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for Project Name field</shortDescription>
+        <value>Project Name</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Helper_Name</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for helper name</shortDescription>
+        <value>Choose a clear, descriptive name for easy identification</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Helper_Target_Object</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for helper Target Object field</shortDescription>
+        <value>Select the Salesforce object where data will be imported</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Helper_Description</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for helper description</shortDescription>
+        <value>Provide details about data source, business purpose, and expected outcomes</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Description</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for Description field</shortDescription>
+        <value>Description</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Target_Object</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for Target Object field</shortDescription>
+        <value>Target Salesforce Object</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Save_Button</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for save button</shortDescription>
+        <value>Save & Continue to Data Source</value>
+    </labels>
+    <labels>
+        <fullName>ProjectForm_Cancel_Button</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for  exit button</shortDescription>
+        <value>Cancel</value>
+    </labels>
+    <!--placeholders-->
+     <labels>
+        <fullName>ImportProject_Description_Placeholder</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Placeholder for import project description</shortDescription>
+        <value>Describe the purpose and scope of this import project...</value>
+    </labels>
+     <labels>
+        <fullName>ImportProject_Name_Placeholder</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Placeholder for import project name</shortDescription>
+        <value>Enter a descriptive project name (e.g., Q4 Contact Import)</value>
+    </labels>
+    <!-- end project project form-->
+
+    <!--select form -->
+    <labels>
+        <fullName>SelectProject_No_Project</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>message for no project found</shortDescription>
+        <value>  No project import yet, please add</value>
+    </labels>
+
+    <labels>
+        <fullName>SelectProject_Card_Title</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>message for no project found</shortDescription>
+        <value>Import projects Informations</value>
+    </labels>
+
+    <labels>
+        <fullName>SelectProject_Close_Button</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Boutton de fermeture du modal</shortDescription>
+        <value>Close</value>
+    </labels>
+
+    <labels>
+        <fullName>SelectProject_Select_Button</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Boutton de selection de projet</shortDescription>
+        <value>Select</value>
+    </labels>
+
+</CustomLabels>

--- a/force-app/main/default/lwc/projectFormComponent/projectFormComponent.html
+++ b/force-app/main/default/lwc/projectFormComponent/projectFormComponent.html
@@ -2,7 +2,7 @@
   @description       : 
   @author            : ChangeMeIn@UserSettingsUnder.SFDoc
   @group             : 
-  @last modified on  : 12-23-2025
+  @last modified on  : 02-16-2026
   @last modified by  : ChangeMeIn@UserSettingsUnder.SFDoc
 -->
 <template>
@@ -12,9 +12,9 @@
       <lightning-icon icon-name="utility:add" alternative-text="Add" class="plus-icons margin-icon"></lightning-icon>
 
       <div class="text-header">
-        <h1>New Project</h1>
+        <h1>{label.projectInfoLabel}</h1>
         <p class="subtitle">
-          Set up your data import project with target object and configuration
+          {label.projectDetailsLabel}
         </p>
       </div>
     </div>
@@ -26,30 +26,29 @@
       <div class="section-header">
         <lightning-icon icon-name="utility:info" alternative-text="Info"
           class="icon-colors"></lightning-icon>
-        <h2>Project Information</h2>
+        <h2>{label.projectInfoSectionLabel}</h2>
       </div>
       <div class="form-group">
         <label class="custom-label name-label" for="project-name">
-          Project Name <span class="required">*</span>
+          {label.projectNameLabel}<span class="required">*</span>
         </label>
         <lightning-input id="project-name" class="rounded-input" style="width: 100%" type="text"
-          placeholder="Enter a descriptive project name (e.g., Q4 Contact Import)"
+          placeholder= {projectNamePlaceholder}
           onchange={handleProjectNameChange}></lightning-input>
       </div>
       <p class="help-text">
-        Choose a clear, descriptive name for easy identification
+        {label.helperNameLabel}
       </p>
 
       <!--Description textarea -->
       <label class="custom-label mb-1 description-label" name="description">
-        Description
+        {label.descriptionLabel}
       </label>
       <lightning-textarea class="input-field rounded-input" name="description" style="margin-top: -1.6rem; "
-        placeholder="Describe the purpose and scope of this import project..."
+        placeholder={descriptionPlaceholder}
         onchange={handleDescriptionChange}></lightning-textarea>
       <p class="help-text">
-        Provide details about data source, business purpose, and expected
-        outcomes
+        {label.helperDescriptionLabel}
       </p>
     
       </div>
@@ -61,18 +60,18 @@
         <div class="section-header">
           <lightning-icon icon-name="utility:campaign" alternative-text="Campaign"
             class="icon-colors "></lightning-icon>
-          <h2>Target Object Configuration</h2>
+          <h2>{label.targetObjectInfoLabel}</h2>
         </div>
   
         <div class="form-grid">
           <div class="form-item">
             <label class="custom-label target-label" for="project-name">
-              Target Salesforce Object <span class="required">*</span>
+              {label.targetObjectLabel} <span class="required">*</span>
             </label>
             <lightning-combobox value={targetObject} options={options} class="rounded-input"
               onchange={handleTargetObjectChange}></lightning-combobox>
             <p class="help-text">
-              Select the Salesforce object where data will be imported
+              {label.helpertargetObjectLabel}
             </p>
           </div>
           <!--Import Operation-->

--- a/force-app/main/default/lwc/projectFormComponent/projectFormComponent.js
+++ b/force-app/main/default/lwc/projectFormComponent/projectFormComponent.js
@@ -1,15 +1,28 @@
 /**
  * 
- * @Last Modification Date: 30-12-2025
- * @Modification: changement composant c-project-form-component du méthode projectnamechange -> namechange
- * Changement composant c-project-form du méthode targetobjectchange -> targetchange
+ * @Last Modification Date: 02-16-2025
+ * @Modification: 
+ * -   ajout I18n
  */
 import { LightningElement, api, track } from "lwc";
-
 //import methods from Controller
 import getCompatibleSObjects from "@salesforce/apex/ImportProjectController.getCompatibleSObjects";
+// Import des labels
+import projectInfoLabel from "@salesforce/label/c.ProjectForm_Title";
+import projectDetailsLabel from "@salesforce/label/c.ProjectForm_Subtitle";
+import targetObjectInfoLabel from "@salesforce/label/c.ProjectForm_Target_Section_Label";
+import projectNameLabel from "@salesforce/label/c.ProjectForm_Name";
+import descriptionLabel from "@salesforce/label/c.ProjectForm_Description"; 
+import projectInfoSectionLabel from "@salesforce/label/c.ProjectForm_Info_Section_Label";
+import targetObjectLabel from "@salesforce/label/c.ProjectForm_Target_Object";
+//helper text labels
+import helperNameLabel from "@salesforce/label/c.ProjectForm_Helper_Name";
+import helperDescriptionLabel from "@salesforce/label/c.ProjectForm_Helper_Description";
+import helpertargetObjectLabel from "@salesforce/label/c.ProjectForm_Helper_Target_Object";
 
-
+//placeholder
+import NAME_PLACEHOLDER from '@salesforce/label/c.ImportProject_Name_Placeholder';
+import DESCRIPTION_PLACEHOLDER from '@salesforce/label/c.ImportProject_Description_Placeholder';
 export default class ProjectFormComponent extends LightningElement {
   @api projectName = "";
   @api description = "";
@@ -17,6 +30,24 @@ export default class ProjectFormComponent extends LightningElement {
   @track options = [];
   @api project;
   @api currentStep;
+
+  label = { 
+    projectDetailsLabel,
+    projectInfoSectionLabel,
+    projectNameLabel,
+    descriptionLabel,
+    targetObjectLabel,
+    projectInfoLabel,
+    projectDetailsLabel,
+    targetObjectInfoLabel,
+    helperNameLabel,
+    helperDescriptionLabel,
+    helpertargetObjectLabel,
+ 
+  };
+
+  descriptionPlaceholder = DESCRIPTION_PLACEHOLDER;
+  projectNamePlaceholder = NAME_PLACEHOLDER;
 
   // Permet au parent de définir des valeurs initiales dans le champs target object
   connectedCallback() {

--- a/force-app/main/default/lwc/projectFormFooterComponent/projectFormFooterComponent.html
+++ b/force-app/main/default/lwc/projectFormFooterComponent/projectFormFooterComponent.html
@@ -10,7 +10,7 @@
           size="x-small"
           title="Cancel"
         ></lightning-icon>
-        <span>Cancel</span>
+        <span>{label.cancelButtonLabel}</span>
       </button>
 
       <!-- Save & Continue Button -->
@@ -26,7 +26,7 @@
           size="small"
           title="Save & Continue"
         ></lightning-icon>
-        <span>Save & Continue to Data Source</span>
+        <span>{label.saveButtonLabel}</span>
       </button>
     </div>
   </footer>

--- a/force-app/main/default/lwc/projectFormFooterComponent/projectFormFooterComponent.js
+++ b/force-app/main/default/lwc/projectFormFooterComponent/projectFormFooterComponent.js
@@ -1,6 +1,15 @@
 import { LightningElement } from "lwc";
 
+//buttons labels
+import saveButtonLabel from "@salesforce/label/c.ProjectForm_Save_Button";
+import cancelButtonLabel from "@salesforce/label/c.ProjectForm_Cancel_Button";
+
 export default class ProjectFormFooterComponent extends LightningElement {
+  label = {
+     saveButtonLabel,
+    cancelButtonLabel
+  }
+  
   //sauvegarde d'un nouveau projet
   handleCreateProject() {
     this.dispatchEvent(new CustomEvent("save"));

--- a/force-app/main/default/translations/fr.translation-meta.xml
+++ b/force-app/main/default/translations/fr.translation-meta.xml
@@ -1,148 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
-    <!-- Project form  -->
-    <labels>
-        <fullName>ProjectForm_Title</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Title for projection information section</shortDescription>
-        <value>New Project</value>
-    </labels>
+<Translations xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customLabels>
+        <label>Nom du Projet</label>
+        <name>ProjectForm_Name</name>
+    </customLabels>
+    <customLabels>
+        <label>Description</label>
+        <name>ProjectForm_Description</name>
+    </customLabels>
+    <customLabels>
+        <label>Objet Salesforce Cible</label>
+        <name>ProjectForm_Target_Object</name>
+    </customLabels>
+    <customLabels>
+        <label>Informations sur le projet</label>
+        <name>ProjectForm_Info_Section_Label</name>
+    </customLabels>
+    <customLabels>
+        <label>Configuration de l'objet cible</label>
+        <name>ProjectForm_Target_Section_Label</name>
+    </customLabels>
+    <customLabels>
+        <label>Choisissez un nom clair et descriptif pour une identification facile</label>
+        <name>ProjectForm_Helper_Name</name>
+    </customLabels>
+    <customLabels>
+        <label>Fournissez des détails sur la source des données, l'objectif commercial et les résultats attendus</label>
+        <name>ProjectForm_Helper_Description</name>
+    </customLabels>
+    <customLabels>
+        <label>Sélectionnez l'objet Salesforce où les données seront importées</label>
+        <name>ProjectForm_Helper_Target_Object</name>       
+    </customLabels>
 
-    <labels>
-        <fullName>ProjectForm_Subtitle</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>SubTitle for projection information section</shortDescription>
-        <value>Set up your data import project with target object and configuration</value>
-    </labels>
+    <customLabels>
+        <label>Nouveau Projet</label>
+        <name>ProjectForm_Title</name>
+    </customLabels>
+    <customLabels>
+        <label>Configurez votre projet d'importation de données avec l'objet cible et la configuration</label>
+        <name>ProjectForm_Subtitle</name>
+    </customLabels>
 
-    <labels>
-        <fullName>ProjectForm_Info_Section_Label</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Section's Project Information</shortDescription>
-        <value>Project Information</value>
-    </labels>
+    <customLabels>
+        <label>Enregistrer et continuer avec la source de données</label>
+        <name>ProjectForm_Save_Button</name>
+    </customLabels>
+    <customLabels>
+        <label>Annuler</label>
+        <name>ProjectForm_Cancel_Button</name>      
+    </customLabels>
+   <customLabels>
+        <label>Décrivez l’objectif et le périmètre de ce projet d’import...</label>
+        <name>ImportProject_Description_Placeholder</name>
+    </customLabels>
+    <customLabels>
+        <label>Saisissez un nom de projet descriptif (ex. : Import des contacts T4)</label>
+        <name>ImportProject_Name_Placeholder</name>
+    </customLabels>
 
-    <labels>
-        <fullName>ProjectForm_Target_Section_Label</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Section's title Target Object Configuration</shortDescription>
-        <value>Target Object Configuration</value>
-    </labels>
 
-    <labels>
-        <fullName>ProjectForm_Name</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Label for Project Name field</shortDescription>
-        <value>Project Name</value>
-    </labels>
+     <!-- SELECT PROJECT - FORM --> 
+    <customLabels>
+        <name>SelectProject_No_Project</name>
+        <label>Aucun projet d'import pour le moment, veuillez en ajouter un.</label>
+    </customLabels>
 
-    <labels>
-        <fullName>ProjectForm_Helper_Name</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Label for helper name</shortDescription>
-        <value>Choose a clear, descriptive name for easy identification</value>
-    </labels>
+    <customLabels>
+        <name>SelectProject_Card_Title</name>
+        <label>Informations sur les projets d'import</label>
+    </customLabels>
 
-    <labels>
-        <fullName>ProjectForm_Helper_Target_Object</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Label for helper Target Object field</shortDescription>
-        <value>Select the Salesforce object where data will be imported</value>
-    </labels>
+    <customLabels>
+        <name>SelectProject_Close_Button</name>
+        <label>Fermer</label>
+    </customLabels>
 
-    <labels>
-        <fullName>ProjectForm_Helper_Description</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Label for helper description</shortDescription>
-        <value>Provide details about data source, business purpose, and expected outcomes</value>
-    </labels>
-
-    <labels>
-        <fullName>ProjectForm_Description</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Label for Description field</shortDescription>
-        <value>Description</value>
-    </labels>
-
-    <labels>
-        <fullName>ProjectForm_Target_Object</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Label for Target Object field</shortDescription>
-        <value>Target Salesforce Object</value>
-    </labels>
-
-    <labels>
-        <fullName>ProjectForm_Save_Button</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Label for save button</shortDescription>
-        <value>Save & Continue to Data Source</value>
-    </labels>
-    <labels>
-        <fullName>ProjectForm_Cancel_Button</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Label for  exit button</shortDescription>
-        <value>Cancel</value>
-    </labels>
-    <!--placeholders-->
-     <labels>
-        <fullName>ImportProject_Description_Placeholder</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Placeholder for import project description</shortDescription>
-        <value>Describe the purpose and scope of this import project...</value>
-    </labels>
-     <labels>
-        <fullName>ImportProject_Name_Placeholder</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Placeholder for import project name</shortDescription>
-        <value>Enter a descriptive project name (e.g., Q4 Contact Import)</value>
-    </labels>
-    <!-- end project project form-->
-
-    <!--select form -->
-    <labels>
-        <fullName>SelectProject_No_Project</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>message for no project found</shortDescription>
-        <value>  No project import yet, please add</value>
-    </labels>
-
-    <labels>
-        <fullName>SelectProject_Card_Title</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>message for no project found</shortDescription>
-        <value>Import projects Informations</value>
-    </labels>
-
-    <labels>
-        <fullName>SelectProject_Close_Button</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Boutton de fermeture du modal</shortDescription>
-        <value>Close</value>
-    </labels>
-
-    <labels>
-        <fullName>SelectProject_Select_Button</fullName>
-        <language>en_US</language>
-        <protected>false</protected>
-        <shortDescription>Boutton de selection de projet</shortDescription>
-        <value>Select</value>
-    </labels>
-
-</CustomLabels>
+    <customLabels>
+        <name>SelectProject_Select_Button</name>
+        <label>Sélectionner</label>
+    </customLabels>
+</Translations>

--- a/force-app/main/default/translations/fr.translation-meta.xml
+++ b/force-app/main/default/translations/fr.translation-meta.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+    <!-- Project form  -->
+    <labels>
+        <fullName>ProjectForm_Title</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Title for projection information section</shortDescription>
+        <value>New Project</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Subtitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>SubTitle for projection information section</shortDescription>
+        <value>Set up your data import project with target object and configuration</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Info_Section_Label</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Section's Project Information</shortDescription>
+        <value>Project Information</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Target_Section_Label</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Section's title Target Object Configuration</shortDescription>
+        <value>Target Object Configuration</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Name</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for Project Name field</shortDescription>
+        <value>Project Name</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Helper_Name</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for helper name</shortDescription>
+        <value>Choose a clear, descriptive name for easy identification</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Helper_Target_Object</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for helper Target Object field</shortDescription>
+        <value>Select the Salesforce object where data will be imported</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Helper_Description</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for helper description</shortDescription>
+        <value>Provide details about data source, business purpose, and expected outcomes</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Description</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for Description field</shortDescription>
+        <value>Description</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Target_Object</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for Target Object field</shortDescription>
+        <value>Target Salesforce Object</value>
+    </labels>
+
+    <labels>
+        <fullName>ProjectForm_Save_Button</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for save button</shortDescription>
+        <value>Save & Continue to Data Source</value>
+    </labels>
+    <labels>
+        <fullName>ProjectForm_Cancel_Button</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label for  exit button</shortDescription>
+        <value>Cancel</value>
+    </labels>
+    <!--placeholders-->
+     <labels>
+        <fullName>ImportProject_Description_Placeholder</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Placeholder for import project description</shortDescription>
+        <value>Describe the purpose and scope of this import project...</value>
+    </labels>
+     <labels>
+        <fullName>ImportProject_Name_Placeholder</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Placeholder for import project name</shortDescription>
+        <value>Enter a descriptive project name (e.g., Q4 Contact Import)</value>
+    </labels>
+    <!-- end project project form-->
+
+    <!--select form -->
+    <labels>
+        <fullName>SelectProject_No_Project</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>message for no project found</shortDescription>
+        <value>  No project import yet, please add</value>
+    </labels>
+
+    <labels>
+        <fullName>SelectProject_Card_Title</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>message for no project found</shortDescription>
+        <value>Import projects Informations</value>
+    </labels>
+
+    <labels>
+        <fullName>SelectProject_Close_Button</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Boutton de fermeture du modal</shortDescription>
+        <value>Close</value>
+    </labels>
+
+    <labels>
+        <fullName>SelectProject_Select_Button</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Boutton de selection de projet</shortDescription>
+        <value>Select</value>
+    </labels>
+
+</CustomLabels>


### PR DESCRIPTION
# Custom Labels Internationalisation du formulaire de création de projets importés

Cette PR introduit la **prise en charge de l’internationalisation** pour le formulaire de création de projets d’import. Les placeholders et labels de l’interface utilisateur sont désormais traduits automatiquement selon la langue de l’utilisateur en Fr
 
[Démo](https://www.loom.com/share/3af101f89141495ba9e876fb8ff7e3a3)

---

## Fonctionnalités ajoutées

- Support de la localisation (Custom Labels) pour le formulaire de création de projets.
- Amélioration des placeholders et libellés pour une meilleure expérience utilisateur.
- Organisation des fichiers de traduction par domaine métier pour faciliter la maintenance et les futures extensions.

---

##  Fichiers créés

- `/default/labels/CustomLabels.labels-meta.xml` 
- `/default/translations/fr.translation-meta.xml`

---

##  Fichiers modifiés

- `projectFormComponent.html` & `projectFormFooterComponent.js`

## Fichiers Obsolètes  
- `projectFormCardComponent.html` & `selectprojectComponent.js` non utilisés 
 

---

##  Placeholders traduits

### Description Placeholder

| Langue | Valeur |
|--------|--------|
| EN     | Describe the purpose and scope of this import project... |
| FR     | Décrivez l’objectif et le périmètre de ce projet d’import... | 

### Nom du projet Placeholder

| Langue | Valeur |
|--------|--------|
| EN     | Enter a descriptive project name (e.g., Q4 Contact Import) |
| FR     | Saisissez un nom de projet descriptif (ex. : Import des contacts T4) | 
